### PR TITLE
feat: add visual mode selection highlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ luac.out
 *.x86_64
 *.hex
 
+.claude
+.DS_Store

--- a/lua/blink-bang-word-light/config.lua
+++ b/lua/blink-bang-word-light/config.lua
@@ -16,6 +16,12 @@ config.settings = {
     guifg = nil,
     guibg = nil,
   },
+  visual_highlight = {
+    enabled = true,
+    mode = "exclusive",
+    max_selection_length = 200,
+    max_selection_lines = 3,
+  },
   enabled = true,
 }
 

--- a/lua/blink-bang-word-light/highlight.lua
+++ b/lua/blink-bang-word-light/highlight.lua
@@ -12,6 +12,7 @@ local PLUG_NAME = "blink-bang-word-light"
 local prev_line = -1
 local prev_start_column = math.huge
 local prev_end_column = -1
+local prev_visual_text = nil
 
 local M = {}
 
@@ -22,6 +23,8 @@ function M.clear_match()
     prev_start_column = math.huge
     prev_end_column = -1
   end
+  -- Also clear visual mode match
+  M.clear_visual_match()
 end
 
 function M.set_highlight(highlight)
@@ -44,6 +47,17 @@ end
 function M.on_cursor_moved(configs)
   if not configs.enabled then
     M.clear_match()
+    return
+  end
+
+  -- In exclusive mode and in visual mode, skip cursor word highlight
+  if configs.visual_highlight.mode == "exclusive" and fn.mode():match('[vV\x16]') then
+    if w.blink_bang_word_light ~= nil then
+      pcall(fn.matchdelete, w.blink_bang_word_light)
+      w.blink_bang_word_light = nil
+      prev_start_column = math.huge
+      prev_end_column = -1
+    end
     return
   end
 
@@ -108,6 +122,93 @@ function M.check_disabled(excluded, bufnr)
   return arr_contains(excluded.buftypes, api.nvim_get_option_value("buftype", { buf = bufnr or 0 }))
       or arr_contains(excluded.filetypes, api.nvim_get_option_value("filetype", { buf = bufnr or 0 }))
       or matches_file_patterns(api.nvim_buf_get_name(bufnr or 0), excluded.patterns)
+end
+
+-- Visual mode selection text retrieval
+local function get_visual_text()
+  if fn.has('nvim-0.10') == 1 and fn.mode():match('[vV\x16]') then
+    -- In visual mode, use 'v' mark (start of visual) and current cursor position
+    local start_pos = fn.getpos("v")
+    local end_pos = fn.getpos(".")
+
+    -- Check if marks are valid (line number > 0)
+    if start_pos[2] == 0 or end_pos[2] == 0 then
+      return nil
+    end
+
+    local region = fn.getregion(
+      start_pos,
+      end_pos,
+      {type = fn.mode()}
+    )
+    return table.concat(region, "\n")
+  end
+  return nil
+end
+
+-- Visual mode selection validation
+local function validate_selection(text, configs)
+  if not text or text == "" then
+    return false
+  end
+
+  if #text > configs.visual_highlight.max_selection_length then
+    return false
+  end
+
+  local line_count = select(2, text:gsub('\n', '\n')) + 1
+  if line_count > configs.visual_highlight.max_selection_lines then
+    return false
+  end
+
+  return true
+end
+
+-- Clear visual mode match
+function M.clear_visual_match()
+  if w.blink_bang_visual_light ~= nil then
+    pcall(fn.matchdelete, w.blink_bang_visual_light)
+    w.blink_bang_visual_light = nil
+    prev_visual_text = nil
+  end
+end
+
+-- Visual mode selection highlight handler
+function M.on_visual_selection(configs)
+  if not configs.visual_highlight.enabled then
+    M.clear_visual_match()
+    return
+  end
+
+  local mode = fn.mode()
+  if not mode:match('[vV\x16]') then
+    M.clear_visual_match()
+    return
+  end
+
+  local selected_text = get_visual_text()
+
+  if not validate_selection(selected_text, configs) then
+    M.clear_visual_match()
+    return
+  end
+
+  -- Cache check
+  if selected_text == prev_visual_text then
+    return
+  end
+  prev_visual_text = selected_text
+
+  M.clear_visual_match()
+
+  -- In exclusive mode, also clear cursor word match
+  if configs.visual_highlight.mode == "exclusive" then
+    M.clear_match()
+  end
+
+  -- Escape and highlight
+  local escaped = fn.escape(selected_text, [=[\/.*$^~[]]=])
+  w.blink_bang_visual_light = matchadd(PLUG_NAME, escaped, -1)
 end
 
 return M

--- a/lua/blink-bang-word-light/init.lua
+++ b/lua/blink-bang-word-light/init.lua
@@ -32,10 +32,25 @@ function M.enable_autocmds()
     end,
   })
 
+  -- Visual mode transition detection
+  vim.api.nvim_create_autocmd('ModeChanged', {
+    group = autocmd_group_id,
+    pattern = { '*:[vV\x16]*', '[vV\x16]*:*' },
+    callback = function()
+      highlight.on_visual_selection(config.settings)
+    end,
+  })
+
+  -- CursorMoved: visual mode uses selection highlight, otherwise word highlight
   vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
     group = autocmd_group_id,
     callback = function()
-      highlight.on_cursor_moved(config.settings)
+      local mode = vim.fn.mode()
+      if mode:match('[vV\x16]') then
+        highlight.on_visual_selection(config.settings)
+      else
+        highlight.on_cursor_moved(config.settings)
+      end
     end,
   })
 


### PR DESCRIPTION
## Summary
Highlight all occurrences of visually selected text throughout the buffer.

## Features
- **Exclusive mode (default)**: Only visual selection highlights in visual mode
- **Concurrent mode (optional)**: Highlights both cursor word and visual selection
- Performance optimized with selection caching
- Configurable limits for selection length and line count
- Auto-clear when exiting visual mode

## Configuration
```lua
require('blink-bang-word-light').setup({
  visual_highlight = {
    enabled = true,              -- Enable visual mode highlight
    mode = "exclusive",          -- "exclusive" or "concurrent"
    max_selection_length = 200,  -- Maximum characters
    max_selection_lines = 3,     -- Maximum lines
  },
})
```

## Technical Details
- Visual mode detection: `ModeChanged` autocmd
- Selection retrieval: `vim.fn.getregion()` (Neovim 0.10+)
- Supports visual, visual-line, and visual-block modes

## Test Plan
- [x] Visual selection highlights matching text
- [x] Highlights update immediately when expanding/shrinking selection
- [x] Highlights clear when exiting visual mode
- [x] Exclusive mode disables cursor word highlight in visual mode
- [x] Syntax check passed